### PR TITLE
Make CMakeList.txt work on the Mac by calling existing `generate_version.sh`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         COMMAND_ERROR_IS_FATAL LAST
     )
-elseif(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Linux")
+elseif(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin")
     execute_process(
         COMMAND bash -c "${CMAKE_SOURCE_DIR}/scripts/generate_version.sh"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/cmake/flags_macros.cmake
+++ b/cmake/flags_macros.cmake
@@ -120,7 +120,7 @@ macro(USE_TQ_LPI2C)
     ${CMAKE_C_FLAGS} \
     -DUSE_LPI2C\ ")
     set(CMAKE_CXX_FLAGS " \
-    ${CMAKE_C_FLAGS} \
+    ${CMAKE_CXX_FLAGS} \
     -DUSE_LPI2C\ ")
 endmacro()
 
@@ -129,6 +129,6 @@ macro(USE_TQ_I2C)
     ${CMAKE_C_FLAGS} \
     -DUSE_I2C\ ")
     set(CMAKE_CXX_FLAGS " \
-    ${CMAKE_C_FLAGS} \
+    ${CMAKE_CXX_FLAGS} \
     -DUSE_I2C \ ")
 endmacro()


### PR DESCRIPTION
On a Mac running `cmake -G .....`  results in an error:

```error
CMake Error at CMakeLists.txt:49 (message):
  Host system was not recognized.  HOST NAME: Darwin
```

This PR fixes this issue by using the `Linux` branch conditional which calls  `generate_version.sh`  which works fine on a Mac.
Within CMake the Mac is reported as `Darwin`.

Once this fix is in place `cmake` runs to completion on the Mac.